### PR TITLE
fix deprecated getNum

### DIFF
--- a/src/config.nim
+++ b/src/config.nim
@@ -64,8 +64,8 @@ proc loadConfig*(filePath: string): Config =
   let rootNode = parseFile(filePath)
 
   result = Config(
-    gap: (rootNode["gap"].getNum(12)).int,
-    displayEdgeGap: (rootNode["displayEdgeGap"].getNum(6)).int,
+    gap: (rootNode["gap"].getInt(12)),
+    displayEdgeGap: (rootNode["displayEdgeGap"].getInt(6)),
 
     bindMap: initTable[KeyEvent, string]()
   )


### PR DESCRIPTION
Removed the deprecated usage of getNum in favor of getInt. It now compiles with the nim 1.2.0 😄 